### PR TITLE
fix: copying logic from Draw function to Shift

### DIFF
--- a/0-imperativeGrid/v0.0/terminals.js
+++ b/0-imperativeGrid/v0.0/terminals.js
@@ -67,13 +67,22 @@ function oShift(direction, distance) {
   this.distance = distance;
 
   this.exec = function () {
-    shift(direction, distance);
+    if (typeof distance == "object") {
+      shift(direction, distance.eval());
+    } else {
+      shift(direction, distance);
+    }
   }
 
   this.toPlantuml = function () {
     params = '"' + this.direction + '"';
     if (this.distance !== undefined) {
-      params += ", " + this.distance;
+      params += ", ";
+      if (typeof this.distance == "number"){
+        params += this.distance;
+      } else {
+        params += this.distance.toPlantuml();
+      }
     }
     return "\n:Shift(" + params + ");";
   }


### PR DESCRIPTION
Addressing the issue #1, this pull request fix it by copying the logic used in the `Draw` function and replacing the one in the `Shift` function. 

Using the same example from the issue:
```js
[
  Shift(
    "south",
    Minus(
      getDistanceEdge("south"), 3
    )
  ),
  Draw(
    "east",
    Plus(
      getDistanceEdge("east"), 1
    )
  )
]
```

Now we get the following output:
```
@startuml

start
:Shift("south", (70 - 3));
:Draw("east", (70 + 1));
stop

@enduml
```

Which is the expected one.